### PR TITLE
Remove duplicate `pipeline :browser` declaration

### DIFF
--- a/phoenix-project/phoenix_final/web/router.ex
+++ b/phoenix-project/phoenix_final/web/router.ex
@@ -1,14 +1,6 @@
 defmodule PhoenixFinal.Router do
   use PhoenixFinal.Web, :router
 
-  pipeline :browser do
-    plug :accepts, ["html"]
-    plug :fetch_session
-    plug :fetch_flash
-    plug :protect_from_forgery
-    plug :put_secure_browser_headers
-  end
-
   pipeline :api do
     plug :accepts, ["json"]
   end


### PR DESCRIPTION
You accidentally added the second one by mistake. I believe the second one is the only one that will be used, as it will probably override the first. I did not verify this claim! But the second one also looks like the one you want, as it has `Auth` plug in it.